### PR TITLE
Fix GeneEdaSubsetPlugin to insert gene IDs as separate rows 

### DIFF
--- a/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/AbstractEdaGenesPlugin.java
+++ b/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/AbstractEdaGenesPlugin.java
@@ -271,7 +271,7 @@ public abstract class AbstractEdaGenesPlugin extends AbstractPlugin {
       String pkColsString = Arrays.stream(_pkColumnNames).map(col -> "ta." + col).collect(Collectors.joining(", "));
       String dynamicAttributes = _filteredDynamicAttributeNames.stream().map(col -> ", tmp." + col).collect(Collectors.joining());
       String geneTranscriptsSql =
-          "select " + pkColsString + ", 'Y' as matched_result" + dynamicAttributes +
+          "select distinct " + pkColsString + ", 'Y' as matched_result" + dynamicAttributes +
           " from apidbtuning.transcriptattributes ta, apidbtuning.geneid gi, " + tmpTableRef + " tmp" +
           " where lower(gi.id) = lower(tmp.gene_source_id) and gi.gene = ta.gene_source_id";
 

--- a/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/AbstractEdaGenesPlugin.java
+++ b/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/AbstractEdaGenesPlugin.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
@@ -123,7 +124,7 @@ public abstract class AbstractEdaGenesPlugin extends AbstractPlugin {
 
   protected abstract Boolean isRetainedRow(String[] edaRow);
 
-  protected abstract Object[] convertToTmpTableRow(String[] edaRow);
+  protected abstract List<Object[]> convertToTmpTableRows(String[] edaRow);
 
   @Override
   public String[] getColumns(PluginRequest request) throws PluginModelException {
@@ -255,7 +256,7 @@ public abstract class AbstractEdaGenesPlugin extends AbstractPlugin {
       LOG.info("Will insert rows into temporary table with SQL: " + insertSql);
 
       FilteredArgumentBatch rowsProvider = new FilteredArgumentBatch(
-          reader, this::isRetainedRow, this::convertToTmpTableRow, tmpTableColumns.size());
+          reader, this::isRetainedRow, this::convertToTmpTableRows, tmpTableColumns.size());
 
       new SQLRunner(_wdkModel.getAppDb().getDataSource(), insertSql, "insert-tmp-gene-vals")
           .executeStatementBatch(rowsProvider);
@@ -312,31 +313,31 @@ public abstract class AbstractEdaGenesPlugin extends AbstractPlugin {
 
     private final BufferedReader _reader;
     private final Predicate<String[]> _rowFilter;
-    private final Function<String[],Object[]> _rowConverter;
+    private final Function<String[],List<Object[]>> _rowConverter;
     private final int _expectedDbRowLength;
     private int _numRowsProvided = 0;
     private int _numRowsSkipped = 0;
-    private String[] _nextRow;
+    // pending rows expanded from a single EDA row (e.g. JSON array gene IDs)
+    private final List<Object[]> _pendingRows = new ArrayList<>();
 
     public FilteredArgumentBatch(
         BufferedReader reader,
         Predicate<String[]> rowFilter,
-        Function<String[],Object[]> rowConverter,
+        Function<String[],List<Object[]>> rowConverter,
         int expectedDbRowLength) {
       _reader = reader;
       _rowFilter = rowFilter;
       _rowConverter = rowConverter;
       _expectedDbRowLength = expectedDbRowLength;
-      setNextRow();
+      fillPending();
     }
 
-    private void setNextRow() {
+    private void fillPending() {
       try {
-        _nextRow = null;
-        while(_reader.ready() && _nextRow == null) {
+        while (_pendingRows.isEmpty() && _reader.ready()) {
           String[] tokens = _reader.readLine().split(TAB);
           if (_rowFilter.test(tokens)) {
-            _nextRow = tokens;
+            _pendingRows.addAll(_rowConverter.apply(tokens));
           }
           else {
             _numRowsSkipped++;
@@ -354,15 +355,16 @@ public abstract class AbstractEdaGenesPlugin extends AbstractPlugin {
 
         @Override
         public boolean hasNext() {
-          return _nextRow != null;
+          return !_pendingRows.isEmpty();
         }
 
         @Override
         public Object[] next() {
           if (!hasNext()) throw new NoSuchElementException();
-          String[] oldNextRow = _nextRow;
-          setNextRow();
-          Object[] dbRow = _rowConverter.apply(oldNextRow);
+          Object[] dbRow = _pendingRows.remove(0);
+          if (_pendingRows.isEmpty()) {
+            fillPending();
+          }
           if (dbRow.length != _expectedDbRowLength) {
             throw new RuntimeException("DB row returned by rowConverter [" +
                 Arrays.stream(dbRow).map(String::valueOf).collect(Collectors.joining(", ")) +

--- a/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
+++ b/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
@@ -2,10 +2,8 @@ package org.apidb.apicomplexa.wsfplugin.eda;
 
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.ws.rs.core.HttpHeaders;
 
@@ -23,8 +21,6 @@ public class GeneEdaSubsetPlugin extends AbstractEdaGenesPlugin {
 
   // Hard-coded variable ID which is expected to contain gene IDs
   private static final String GENE_ID_VARIABLE_ID = "VEUPATHDB_GENE_ID";
-
-  private final Set<String> _seenGeneIds = new HashSet<>();
 
   @Override
   protected InputStream getEdaTabularDataStream(String edaBaseUrl, Map<String, String> authHeader) throws Exception {
@@ -101,16 +97,11 @@ public class GeneEdaSubsetPlugin extends AbstractEdaGenesPlugin {
     if (geneIdValue.startsWith("[")) {
       JSONArray ids = new JSONArray(geneIdValue);
       for (int i = 0; i < ids.length(); i++) {
-        String id = ids.getString(i);
-        if (_seenGeneIds.add(id.toLowerCase())) {
-          rows.add(new Object[] { id });
-        }
+        rows.add(new Object[] { ids.getString(i) });
       }
     }
     else {
-      if (_seenGeneIds.add(geneIdValue.toLowerCase())) {
-        rows.add(new Object[] { geneIdValue });
-      }
+      rows.add(new Object[] { geneIdValue });
     }
     return rows;
   }

--- a/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
+++ b/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
@@ -2,6 +2,7 @@ package org.apidb.apicomplexa.wsfplugin.eda;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -88,9 +89,21 @@ public class GeneEdaSubsetPlugin extends AbstractEdaGenesPlugin {
   }
 
   @Override
-  protected Object[] convertToTmpTableRow(String[] edaRow) {
-    // this plugin's EDA response contains two columns: [ stable ID, gene ID ]
-    return new Object[] { edaRow[1] };
+  protected List<Object[]> convertToTmpTableRows(String[] edaRow) {
+    // this plugin's EDA response contains two columns: [ stable ID, gene ID(s) ]
+    // the gene ID column may contain a JSON array of IDs; expand each into its own row
+    List<Object[]> rows = new ArrayList<>();
+    String geneIdValue = edaRow[1].trim();
+    if (geneIdValue.startsWith("[")) {
+      JSONArray ids = new JSONArray(geneIdValue);
+      for (int i = 0; i < ids.length(); i++) {
+        rows.add(new Object[] { ids.getString(i) });
+      }
+    }
+    else {
+      rows.add(new Object[] { geneIdValue });
+    }
+    return rows;
   }
 
 }

--- a/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
+++ b/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
@@ -94,15 +94,19 @@ public class GeneEdaSubsetPlugin extends AbstractEdaGenesPlugin {
     // the gene ID column may contain a JSON array of IDs; expand each into its own row
     List<Object[]> rows = new ArrayList<>();
     String geneIdValue = edaRow[1].trim();
-    if (geneIdValue.startsWith("[")) {
-      JSONArray ids = new JSONArray(geneIdValue);
-      for (int i = 0; i < ids.length(); i++) {
-        rows.add(new Object[] { ids.getString(i) });
+    try {
+      if (geneIdValue.startsWith("[")) {
+        JSONArray ids = new JSONArray(geneIdValue);
+        for (int i = 0; i < ids.length(); i++) {
+          rows.add(new Object[] { ids.getString(i) });
+        }
+        return rows;
       }
     }
-    else {
-      rows.add(new Object[] { geneIdValue });
+    catch (JSONException e) {
+      LOG.warn("Failed to parse gene ID as JSON array, treating as plain ID: " + geneIdValue);
     }
+    rows.add(new Object[] { geneIdValue });
     return rows;
   }
 

--- a/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
+++ b/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
@@ -13,6 +13,7 @@ import org.gusdb.fgputil.Tuples.TwoTuple;
 import org.gusdb.fgputil.client.ClientUtil;
 import org.gusdb.wsf.plugin.PluginModelException;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class GeneEdaSubsetPlugin extends AbstractEdaGenesPlugin {

--- a/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
+++ b/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaSubsetPlugin.java
@@ -2,8 +2,10 @@ package org.apidb.apicomplexa.wsfplugin.eda;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.core.HttpHeaders;
 
@@ -21,6 +23,8 @@ public class GeneEdaSubsetPlugin extends AbstractEdaGenesPlugin {
 
   // Hard-coded variable ID which is expected to contain gene IDs
   private static final String GENE_ID_VARIABLE_ID = "VEUPATHDB_GENE_ID";
+
+  private final Set<String> _seenGeneIds = new HashSet<>();
 
   @Override
   protected InputStream getEdaTabularDataStream(String edaBaseUrl, Map<String, String> authHeader) throws Exception {
@@ -97,11 +101,16 @@ public class GeneEdaSubsetPlugin extends AbstractEdaGenesPlugin {
     if (geneIdValue.startsWith("[")) {
       JSONArray ids = new JSONArray(geneIdValue);
       for (int i = 0; i < ids.length(); i++) {
-        rows.add(new Object[] { ids.getString(i) });
+        String id = ids.getString(i);
+        if (_seenGeneIds.add(id.toLowerCase())) {
+          rows.add(new Object[] { id });
+        }
       }
     }
     else {
-      rows.add(new Object[] { geneIdValue });
+      if (_seenGeneIds.add(geneIdValue.toLowerCase())) {
+        rows.add(new Object[] { geneIdValue });
+      }
     }
     return rows;
   }

--- a/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaVizWithComputePlugin.java
+++ b/WSFPlugin/src/main/java/org/apidb/apicomplexa/wsfplugin/eda/GeneEdaVizWithComputePlugin.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -393,9 +394,11 @@ public class GeneEdaVizWithComputePlugin extends AbstractEdaGenesPlugin {
   }
 
   @Override
-  protected Object[] convertToTmpTableRow(String[] edaRow) {
+  protected List<Object[]> convertToTmpTableRows(String[] edaRow) {
     //LOG.info("Converting edaRow of size " + edaRow.length + " from temporary file (tabular), array = [ " + String.join(", ", edaRow) + " ]");
-    return new Object[] { edaRow[0], edaRow[1], edaRow[2] };
+    List<Object[]> rows = new ArrayList<>();
+    rows.add(new Object[] { edaRow[0], edaRow[1], edaRow[2] });
+    return rows;
   }
 
   /**


### PR DESCRIPTION
Rod malaria phenotype (plasmodb) has multiple organisms so the eda returns genes from multiple orgs as  JSON array

The EDA tabular endpoint returns gene IDs as a JSON array in a single cell (e.g. ["PBANKA_1349800","PF3D7_1335900"]), but the code was trying to insert the whole array string as a single VARCHAR(30) value. Changed convertToTmpTableRow to convertToTmpTableRows (returning List<Object[]>) so each gene ID in the array becomes its own row in the temporary table.

Tested on my dev site.  Other eda searches working too